### PR TITLE
don't prefix shebang line

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -143,6 +143,9 @@ const pass1 = () => {
         cmdfile,
         gitcommands
           .map((cmd) => {
+            if(cmd.startsWith("#!/")) {
+              return cmd
+            }
             return opts.git ? `git ${cmd}` : cmd
           })
           .join("\n"),


### PR DESCRIPTION
kebab-ify-files generates a script file where all commands are prefixed with `git` This prefix is also happening for the first (shebang) line causing the script to fail.

current:
```
git #!/bin/bash
git mv ...
```

with my fix:
```
#!/bin/bash
git mv ...
```